### PR TITLE
Acknowledge project custom lib_ignore setting

### DIFF
--- a/builder/frameworks/esp8266-rtos-sdk.py
+++ b/builder/frameworks/esp8266-rtos-sdk.py
@@ -672,7 +672,7 @@ build_dirs = [
 build_excl = [
     "bootloader", "esptool_py", "partition_table",
 ]
-lib_ignore=env.get('LIB_IGNORE',[])
+lib_ignore=env.GetProjectOption("lib_ignore", [])
 if isdir("c:\\users\\test"):
 	k = build_dirs+build_excl
 	new_lib=[]


### PR DESCRIPTION
I followed the PlatformIO's lib_ignore documentation to try to reduce components built, but found the setting wasn't effective. After some tweaking around, I figured this line seems to be the culprit.

I am a newbie of PlatformIO, so I have not idea whether I did the right thing... :P Feel free to critique!